### PR TITLE
[#29] report contents of stdout and stderr of native git invocations on error

### DIFF
--- a/src/test/kotlin/io/github/georgberky/maven/plugins/depsupdate/NativeGitProviderErrorHandlingTest.kt
+++ b/src/test/kotlin/io/github/georgberky/maven/plugins/depsupdate/NativeGitProviderErrorHandlingTest.kt
@@ -18,8 +18,8 @@ internal class NativeGitProviderErrorHandlingTest {
     @BeforeEach
     internal fun setUp() {
         gitProvider = object : NativeGitProvider(tempDir.toPath()) {
-            override fun run(vararg command: String): Pair<Int, String> {
-                return Pair(returnValue, processOutput)
+            override fun run(vararg command: String): Triple<Int, String, String> {
+                return Triple(returnValue, processOutput, "")
             }
         }
     }


### PR DESCRIPTION
Helps to identify `native git rc=128`, but does not fix (not!) #29 yet.