### PR TITLE
[SITE] publish a maven site on github pages

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ steps:
     commands:
       - apt update
       - apt install git -y
-      - mvn -V clean verify --fail-at-end --batch-mode
+      - mvn -V verify site site:stage --fail-at-end --batch-mode -Pdocs
   - name: coverage
     image: plugins/codecov
     settings:

--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ If a more recent version of a dependency is found, the plugin will
 ```sh
 mvn io.github.georgberky.maven.plugins.depsupdate:dependency-update-maven-plugin:update
 ```
+
+## Goals
+
+### update
+
+[Update Mojo](https://pages.github.com/georgberky/dependency-update-maven-plugin/)

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,10 @@
             <name>Georg Berky</name>
             <email>hallo@berky.dev</email>
         </developer>
+        <developer>
+            <name>Benjamin Marwell</name>
+            <email>bmarwell@apache.org</email>
+        </developer>
     </developers>
 
     <scm>
@@ -52,10 +56,16 @@
             <id>ossrh</id>
             <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
+        <site>
+            <id>gh_pages</id>
+            <name>Maven Site on GitHub Pages</name>
+            <url>https://pages.github.com/georgberky/dependency-update-maven-plugin/</url>
+        </site>
     </distributionManagement>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.version>3.6.3</maven.version>
         <kotlin.version>1.6.0</kotlin.version>
         <maven-plugin.version>3.6.0</maven-plugin.version>
@@ -255,6 +265,21 @@
                     <artifactId>maven-install-plugin</artifactId>
                     <version>2.5.2</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.12.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-project-info-reports-plugin</artifactId>
+                    <version>3.3.0</version>
+                    <configuration>
+                        <pluginManagementExcludes>
+                            <exclude>org.eclipse.m2e:lifecycle-mapping</exclude>
+                        </pluginManagementExcludes>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -384,6 +409,40 @@
             </plugin>
         </plugins>
     </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>index</report>
+                            <report>summary</report>
+                            <report>dependency-info</report>
+                            <report>modules</report>
+                            <report>team</report>
+                            <report>scm</report>
+                            <report>issue-management</report>
+                            <report>mailing-lists</report>
+                            <report>dependency-management</report>
+                            <report>dependencies</report>
+                            <report>dependency-convergence</report>
+                            <report>ci-management</report>
+                            <report>plugin-management</report>
+                            <report>plugins</report>
+                            <report>distribution-management</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </reporting>
 
     <profiles>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <maven.version>3.6.3</maven.version>
         <kotlin.version>1.6.0</kotlin.version>
         <maven-plugin.version>3.6.0</maven-plugin.version>
+        <dokka.version>1.7.10</dokka.version>
         <itf.version>0.10.0</itf.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -441,10 +442,50 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>report</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
         </plugins>
     </reporting>
 
     <profiles>
+        <profile>
+            <id>docs</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jetbrains.dokka</groupId>
+                        <artifactId>dokka-maven-plugin</artifactId>
+                        <version>${dokka.version}</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>javadocJar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <dokkaPlugins>
+                                <plugin>
+                                    <groupId>org.jetbrains.dokka</groupId>
+                                    <artifactId>kotlin-as-java-plugin</artifactId>
+                                    <version>${dokka.version}</version>
+                                </plugin>
+                            </dokkaPlugins>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>release</id>
             <build>

--- a/release.sh
+++ b/release.sh
@@ -1,7 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
-set -o pipefail
+set -eo pipefail
 
 # Trap not-normal exit signals: 1/HUP, 2/INT, 3/QUIT, 15/TERM
 trap catch_sig 1 2 3 15
@@ -10,7 +9,7 @@ trap 'catch_err ${LINENO}' ERR
 
 function clean_exit {
   echo "Exiting - version state may be inconsistent!"
-  exit $1
+  exit "$1"
 }
 
 function catch_err() {
@@ -30,6 +29,26 @@ function catch_sig() {
     clean_exit $exit_status
 }
 
+deploy_site() {
+    local upstream_url="${1}"
+    local root_dir="$PWD"
+
+    mkdir -p "$PWD/target"
+    cd "$PWD/target"
+    git clone --depth=1 --branch "gh_site" "${upstream_url}" "gh_site" || true
+    if [ ! -d "gh_site" ]; then
+        echo "[INFO] Initial creation of new orphan branch gh_site."
+        git clone --depth=1 "${upstream_url}" "gh_site"
+        cd gh_site || exit 1
+        git checkout --orphan "gh_site"
+        rm '.gitignore'
+    fi
+
+    rm -rf "${PWD}/."
+    rsync -a "$root_dir/target/staging/." .
+    cd "${root_dir}"
+}
+
 if [ $# -ne 2 ]; then
   echo "Usage: release.sh <release_version> <new_version>"
   exit 1
@@ -38,15 +57,16 @@ fi
 release_version=$1
 new_version=$2
 
-mvn versions:set -DnewVersion=$release_version -DgenerateBackupPoms=false
+mvn versions:set "-DnewVersion=$release_version" -DgenerateBackupPoms=false
 
 git commit -a -m "$release_version release"
-git tag -a $release_version -a -m "$release_version release"
+git tag -a "$release_version" -a -m "$release_version release"
 
-mvn clean deploy -DskipTests -Prelease
+mvn clean site site:stage deploy -DskipTests -Prelease
+deploy_site "$(git remote get-url origin)"
 
-mvn versions:set -DnewVersion=$new_version -DgenerateBackupPoms=false
+mvn versions:set "-DnewVersion=$new_version" -DgenerateBackupPoms=false
 git commit -a -m "Preparing $new_version iteration"
 
 git push
-git push origin $release_version
+git push origin "$release_version"

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,0 +1,12 @@
+<project xmlns="http://maven.apache.org/DECORATION/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 http://maven.apache.org/xsd/decoration-1.0.0.xsd">
+  <body>
+    <menu name="Overview">
+      <item name="Introduction" href="index.html"/>
+      <item name="Goals" href="plugin-info.html"/>
+      <item name="Summary" href="summary.html"/>
+      <item name="SCM" href="scm.html"/>
+    </menu>
+  </body>
+</project>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -6,6 +6,19 @@
       <item name="Introduction" href="index.html"/>
       <item name="Goals" href="plugin-info.html"/>
       <item name="Summary" href="summary.html"/>
+      <item name="Licenses" href="licenses.html"/>
+      <item name="Project Info" href="project-info.html"/>
+      <item name="Team" href="team.html"/>
+      <!-- not useful -->
+      <!--item name="Dependency Info" href="dependency-info.html"/-->
+    </menu>
+    <menu name="Developer Information">
+      <item name="Jacoco Coverage" href="jacoco/index.html"/>
+      <item name="Dependencies" href="dependencies.html"/>
+      <item name="Dependency Convergence" href="dependency-convergence.html"/>
+      <item name="Plugin Management" href="plugin-management.html"/>
+      <item name="Plugins" href="plugins.html"/>
+      <item name="Project Reports" href="project-reports.html"/>
       <item name="SCM" href="scm.html"/>
     </menu>
   </body>


### PR DESCRIPTION
Contents of this PR:

* Creating an orphan branch `gh_site`, hosting the maven-site.
* The maven-site is useful for the generated documentation. Maven users will want to see the generates `goals` documentation.
* Adds a new profile `docs` which will generate javadoc documentation using dokka. I would recommend to move the source-plugin to this profile as well, you don't need it in your everyday verify goal as a developer. It is only needed for releases.

Not in the scope of this PR:

* convert all of this stuff to [`jreleaser`](https://jreleaser.org/). 😃 
* move source-plugin to the `docs` profile.
* Fix docs
* Tests. I cannot test the release script easily, as I do not have push access. I might change the distribution URL  for testing, though. Consider this untested unless noted otherwise.
* Adding javadocs to the site. Sadly, [dokka does not support report goals](https://github.com/Kotlin/dokka/issues/267).