### PR TITLE
[#48] exclude reactor projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,8 +164,8 @@
         </dependency>
         <dependency>
             <groupId>io.mockk</groupId>
-            <artifactId>mockk</artifactId>
-            <version>1.9.3</version>
+            <artifactId>mockk-jvm</artifactId>
+            <version>1.12.8</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/kotlin/io/github/georgberky/maven/plugins/depsupdate/UpdateMojo.kt
+++ b/src/main/kotlin/io/github/georgberky/maven/plugins/depsupdate/UpdateMojo.kt
@@ -3,6 +3,7 @@ package io.github.georgberky.maven.plugins.depsupdate
 import org.apache.maven.artifact.factory.ArtifactFactory
 import org.apache.maven.artifact.metadata.ArtifactMetadataSource
 import org.apache.maven.artifact.repository.ArtifactRepository
+import org.apache.maven.execution.MavenSession
 import org.apache.maven.plugin.AbstractMojo
 import org.apache.maven.plugins.annotations.Component
 import org.apache.maven.plugins.annotations.Mojo
@@ -10,8 +11,11 @@ import org.apache.maven.plugins.annotations.Parameter
 import org.apache.maven.project.MavenProject
 import org.apache.maven.settings.Settings
 
+
 @Mojo(name = "update")
 class UpdateMojo : AbstractMojo() {
+    @Parameter(defaultValue = "\${session}", readonly = true, required = true)
+    lateinit var mavenSession: MavenSession
     @Parameter(defaultValue = "\${project}", required = true)
     lateinit var mavenProject: MavenProject
     @Parameter(defaultValue = "\${localRepository}", required = true)
@@ -41,7 +45,8 @@ class UpdateMojo : AbstractMojo() {
                     mavenProject = mavenProject,
                     artifactMetadataSource = artifactMetadataSource,
                     localRepository = localRepository,
-                    artifactFactory = artifactFactory
+                    artifactFactory = artifactFactory,
+                    mavenSession = mavenSession
             )
             .updates
             .onEach { println("execute im mojo: latestVersion: '${it.latestVersion}' / version:'${it.version}'") }

--- a/src/test/kotlin/io/github/georgberky/maven/plugins/depsupdate/UpdateResolverTest.kt
+++ b/src/test/kotlin/io/github/georgberky/maven/plugins/depsupdate/UpdateResolverTest.kt
@@ -7,6 +7,8 @@ import org.apache.maven.artifact.factory.ArtifactFactory
 import org.apache.maven.artifact.metadata.ArtifactMetadataSource
 import org.apache.maven.artifact.repository.ArtifactRepository
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion
+import org.apache.maven.artifact.versioning.VersionRange
+import org.apache.maven.execution.MavenSession
 import org.apache.maven.model.Dependency
 import org.apache.maven.model.DependencyManagement
 import org.apache.maven.model.Model
@@ -14,6 +16,7 @@ import org.apache.maven.plugin.testing.ArtifactStubFactory
 import org.apache.maven.project.MavenProject
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.tuple
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import java.io.File
@@ -24,7 +27,10 @@ internal class UpdateResolverTest {
     private val junitDependency = dependency("org.junit.jupiter", "junit-jupiter", "5.5.2")
     private val assertJDependency = dependency("org.assertj", "assertj-core", "3.15.0")
     private val assertJArtifact = artifact("org.assertj", "assertj-core", "3.15.0")
-
+    private val reactorModuleA = dependency("com.text", "moduleA", "1.0.0-SNAPSHOT")
+    private val reactorModuleAArtifact = artifact("com.text", "moduleA", "1.0.0-SNAPSHOT")
+    private val reactorModuleB = dependency("com.text", "moduleB", "1.0.0-SNAPSHOT")
+    private val reactorModuleBArtifact = artifact("com.text", "moduleB", "1.0.0-SNAPSHOT")
 
     @MockK
     lateinit var metadataSourceMock : ArtifactMetadataSource
@@ -35,13 +41,26 @@ internal class UpdateResolverTest {
     @MockK
     lateinit var artifactFactoryMock : ArtifactFactory
 
+    @MockK
+    lateinit var mavenSession: MavenSession
+
+    @BeforeEach
+    fun setUpMocks() {
+        every { mavenSession.projects } returns listOf()
+    }
 
     @Test
     fun parentUpdate() {
         val project = projectWithParent()
         every { metadataSourceMock.retrieveAvailableVersions(project.parentArtifact, any(), any()) } returns listOf( DefaultArtifactVersion("1.0.0") )
 
-        val updateResolverUnderTest = UpdateResolver(project, metadataSourceMock, localRepositoryMock, artifactFactoryMock)
+        val updateResolverUnderTest = UpdateResolver(
+            project,
+            metadataSourceMock,
+            localRepositoryMock,
+            artifactFactoryMock,
+            mavenSession
+        )
 
         assertThat(updateResolverUnderTest.parentUpdates)
                 .hasSize(1)
@@ -60,7 +79,13 @@ internal class UpdateResolverTest {
         every { artifactFactoryMock.createDependencyArtifact(junitDependency) } returns junitArtifact
         every { artifactFactoryMock.createDependencyArtifact(assertJDependency) } returns assertJArtifact
 
-        val updateResolverUnderTest = UpdateResolver(project, metadataSourceMock, localRepositoryMock, artifactFactoryMock)
+        val updateResolverUnderTest = UpdateResolver(
+            project,
+            metadataSourceMock,
+            localRepositoryMock,
+            artifactFactoryMock,
+            mavenSession
+        )
 
         assertThat(updateResolverUnderTest.dependencyUpdates)
                 .hasSize(2)
@@ -76,7 +101,13 @@ internal class UpdateResolverTest {
         every { artifactFactoryMock.createDependencyArtifact(junitDependency) } returns junitArtifact
         every { artifactFactoryMock.createDependencyArtifact(assertJDependency) } returns assertJArtifact
 
-        val updateResolverUnderTest = UpdateResolver(project, metadataSourceMock, localRepositoryMock, artifactFactoryMock)
+        val updateResolverUnderTest = UpdateResolver(
+            project,
+            metadataSourceMock,
+            localRepositoryMock,
+            artifactFactoryMock,
+            mavenSession
+        )
 
         assertThat(updateResolverUnderTest.dependencyManagementUpdates)
                 .hasSize(2)
@@ -86,10 +117,52 @@ internal class UpdateResolverTest {
     }
 
     @Test
+    fun reactorProjectSkipsReactorModules() {
+        val project = projectWithReactorDependencyManagement()
+
+        val reactorModelA = Model()
+        reactorModelA.groupId = reactorModuleA.groupId
+        reactorModelA.artifactId = reactorModuleA.artifactId
+        reactorModelA.version = reactorModuleA.version
+        reactorModelA.packaging = "jar"
+        val reactorModuleAProject = MavenProject(reactorModelA)
+
+        val reactorModelB = Model()
+        reactorModelB.groupId = reactorModuleB.groupId
+        reactorModelB.artifactId = reactorModuleB.artifactId
+        reactorModelB.version = reactorModuleB.version
+        reactorModelB.packaging = "jar"
+        val reactorModuleBProject = MavenProject(reactorModelB)
+
+
+        every { mavenSession.projects } returns listOf( reactorModuleAProject, reactorModuleBProject )
+        every { artifactFactoryMock.createDependencyArtifact(reactorModuleA) } returns reactorModuleAArtifact
+        every { artifactFactoryMock.createDependencyArtifact(reactorModuleB) } returns reactorModuleBArtifact
+        every { metadataSourceMock.retrieveAvailableVersions(any(), any(), any()) } returns listOf( DefaultArtifactVersion("6.0.0") )
+
+        val updateResolverUnderTest = UpdateResolver(
+            project,
+            metadataSourceMock,
+            localRepositoryMock,
+            artifactFactoryMock,
+            mavenSession
+        )
+
+        assertThat(updateResolverUnderTest.dependencyManagementUpdates)
+            .hasSize(0)
+    }
+
+    @Test
     fun nullDependencyUpdates() {
         // given
         val project = projectWithDependencies()
-        val updateResolverUnderTest = UpdateResolver(project, metadataSourceMock, localRepositoryMock, artifactFactoryMock)
+        val updateResolverUnderTest = UpdateResolver(
+            project,
+            metadataSourceMock,
+            localRepositoryMock,
+            artifactFactoryMock,
+            mavenSession
+        )
         every { artifactFactoryMock.createDependencyArtifact(junitDependency) } returns null
         every { artifactFactoryMock.createDependencyArtifact(assertJDependency) } returns assertJArtifact
 
@@ -128,6 +201,17 @@ internal class UpdateResolverTest {
         return project
     }
 
+    private fun projectWithReactorDependencyManagement(): MavenProject {
+        val project = MavenProject()
+        val originalModel = Model()
+        val dependencyManagement = DependencyManagement()
+        dependencyManagement.dependencies = listOf(reactorModuleA, reactorModuleB)
+        originalModel.dependencyManagement = dependencyManagement
+        project.originalModel = originalModel
+        project.file = File("src/test/resources/poms/dependencyManagementPom.xml")
+        return project
+    }
+
     private fun dependency(groupId: String, artifactId: String, version: String): Dependency {
         val dependency = Dependency()
         dependency.groupId = groupId
@@ -137,5 +221,13 @@ internal class UpdateResolverTest {
     }
 
     private fun artifact(groupId: String, artifactId: String, version: String) =
-            ArtifactStubFactory().createArtifact(groupId, artifactId, version)
+        ArtifactStubFactory().createArtifact(
+            groupId,
+            artifactId,
+            VersionRange.createFromVersion(version),
+            "compile",
+            "jar",
+            "",
+            false
+        )
 }


### PR DESCRIPTION
fixes #48

This PR will exclude reactor projects. See description from the issue.

Contents:

* Added mavenSession to read projects
* Updated tests to have a mavenSession
* Verified that in a project with dependencyManagement, no reactor dependency is being updated.