### PR TITLE
[#56] Update mockk test dependency to 1.12.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,8 +164,8 @@
         </dependency>
         <dependency>
             <groupId>io.mockk</groupId>
-            <artifactId>mockk</artifactId>
-            <version>1.9.3</version>
+            <artifactId>mockk-jvm</artifactId>
+            <version>1.12.8</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
labels = dependency update
fixes #56 
depends on https://github.com/georgberky/dependency-update-maven-plugin/pull/55