### PR TITLE
[#11] Uses spotless for ktlint/formatting.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,8 @@
         <maven-plugin.version>3.6.0</maven-plugin.version>
         <dokka.version>1.7.10</dokka.version>
         <itf.version>0.10.0</itf.version>
+        <spotless.version>2.27.1</spotless.version>
+        <ktlint.version>0.47.1</ktlint.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
@@ -281,6 +283,13 @@
                         </pluginManagementExcludes>
                     </configuration>
                 </plugin>
+
+                <!-- 3rd party plugins -->
+                <plugin>
+                    <groupId>com.diffplug.spotless</groupId>
+                    <artifactId>spotless-maven-plugin</artifactId>
+                    <version>${spotless.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -419,6 +428,26 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <kotlin>
+                        <ktlint>
+                            <version>${ktlint.version}</version>
+                        </ktlint>
+                    </kotlin>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
fix #11 / fixes #11.

Fails b/c formatting is applied in https://github.com/georgberky/dependency-update-maven-plugin/pull/66, not this PR.