### PR TITLE
Update Java to 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,16 +10,16 @@ on:
 
 jobs:
   jdk:
-    name: "JDK 11 Eclipse Temurin"
+    name: "JDK 17 Eclipse Temurin"
     runs-on: ubuntu-latest
-    container: "maven:3.8.6-eclipse-temurin-11-focal"
+    container: "maven:3.8.6-eclipse-temurin-17-focal"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: maven-jdk11-${{ hashFiles('**/pom.xml') }}
-          restore-keys: maven-jdk11
+          key: maven-jdk-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-jdk
       - name: 'Build'
         run: |
           git config --global user.email "noreply@dependency-plugin.invalid"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.iml
 .idea/
 target/
-.DS_Store
+**/.DS_Store

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,4 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
 java=17.0.9-tem
+maven=3.9.6

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=11.0.17-tem
+java=17.0.9-tem

--- a/pom.xml
+++ b/pom.xml
@@ -66,15 +66,15 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.version>3.6.3</maven.version>
+        <maven.version>3.8.8</maven.version>
         <kotlin.version>1.6.0</kotlin.version>
-        <maven-plugin.version>3.6.0</maven-plugin.version>
+        <maven-plugin.version>3.10.2</maven-plugin.version>
         <dokka.version>1.7.10</dokka.version>
         <itf.version>0.11.0</itf.version>
         <spotless.version>2.27.1</spotless.version>
         <ktlint.version>0.47.1</ktlint.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <jgit.version>6.4.0.202211300538-r</jgit.version>
     </properties>
 


### PR DESCRIPTION
This MR updates Java to 17, for both the Github Actions build and the local build in pom.xml. 

It also updates Maven to 3.9.6 for the build, and 3.8.8 for the maven-plugin-plugin.